### PR TITLE
tb-3: Fix generated typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/projects/typed-bytes/README.md
+++ b/projects/typed-bytes/README.md
@@ -30,7 +30,7 @@ No need for install, run the above code directly with this tweak:
 
 ```diff
 -import * as tb from "typed-bytes";
-+import * as tb from "https://raw.githubusercontent.com/voltrevo/monorepo/c1ff75a/projects/typed-bytes/mod.ts";
++import * as tb from "https://raw.githubusercontent.com/voltrevo/monorepo/77e8f7e/projects/typed-bytes/mod.ts";
 ```
 
 ## About

--- a/projects/typed-bytes/npm-package/package.json
+++ b/projects/typed-bytes/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-bytes",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A public domain binary encoding library for TypeScript.",
   "main": "build/src/index.js",
   "scripts": {


### PR DESCRIPTION
Resolves #3 by simplifying the way `tb.Object` type inference works.

```diff
-function Object_<T extends Record<string, unknown>>(
-  elements: {
-    [K in keyof T]: Bicoder<T[K]>;
-  },
-): Bicoder<T> {
+function Object_<T extends Record<string, AnyBicoder>>(
+  elements: T,
+): Bicoder<
+  {
+    [K in keyof T]: TypeOf<T[K]>;
+  }
+> {
```

It's better for the type parameter to be exactly the same as an argument and then be explicit about what the return type should be, instead of using the type parameter for the return type and ask the compiler to work backwards.

Interestingly, TypeScript handles this just fine within the same project, but if you generate `.d.ts` types for a library, it gets confused and starts using `any`. This caused the issue to fly under the radar until recently.