### PR TITLE
Allow fields to be provided in a different order when encoding object

### DIFF
--- a/projects/typed-bytes/src/bicoders.ts
+++ b/projects/typed-bytes/src/bicoders.ts
@@ -218,8 +218,8 @@ function Object_<T extends Record<string, AnyBicoder>>(
 
   return new Bicoder<Value>({
     write(stream, value) {
-      for (const [k, v] of globals.Object.entries(value)) {
-        stream.write(elements[k], v as T[typeof k]);
+      for (const k of globals.Object.keys(elements)) {
+        stream.write(elements[k], value[k] as T[typeof k]);
       }
     },
     read(stream) {

--- a/projects/typed-bytes/tests/index.test.ts
+++ b/projects/typed-bytes/tests/index.test.ts
@@ -429,3 +429,19 @@ Deno.test("bicode recursive type", () => {
 
   assertEquals(decodedNumbers, numbers);
 });
+
+Deno.test("can decode correctly after encoding an object with fields in a different order", () => {
+  const Obj = tb.Object({
+    a: tb.string,
+    b: tb.string,
+  });
+
+  const buf = Obj.encode({
+    b: "b",
+    a: "a",
+  });
+
+  const decoded = Obj.decode(buf);
+
+  assertEquals(decoded.a, "a");
+});


### PR DESCRIPTION
Fixes #5.